### PR TITLE
Use Buf arm64 releases on M1 Macs

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -5,8 +5,9 @@ on:
     paths:
       - "bin/*"
   push:
-    paths:
-      - "bin/*"
+    branches:
+      - "main"
+      - "master"
 
 jobs:
   lint:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -5,8 +5,9 @@ on:
     paths:
       - "bin/*"
   push:
-    paths:
-      - "bin/*"
+    branches:
+      - "main"
+      - "master"
   schedule:
     - cron: "0 0 * * *"
 

--- a/.shellcheckrc
+++ b/.shellcheckrc
@@ -1,0 +1,6 @@
+# Explicit default (even though the default currently is bash)
+shell=bash
+
+# Add the directory of the currently checked script to the list of allowed paths to source from
+source-path=SCRIPTDIR
+source-path=SCRIPTDIR/bin

--- a/bin/download
+++ b/bin/download
@@ -3,6 +3,24 @@
 : "${ASDF_INSTALL_VERSION:?"Missing ASDF_INSTALL_VERSION"}"
 : "${ASDF_DOWNLOAD_PATH:?"Missing ASDF_DOWNLOAD_PATH"}"
 
+mac_arm64_binary() {
+  # Buf only started publishing Mac M1 Arm binaries on v0.42.0
+  local major_minor major minor
+
+  major_minor="${ASDF_INSTALL_VERSION%.*}"
+  major="${major_minor%%.*}"
+  major="${major##+(0)}" # remove leading zeros
+  minor="${major_minor##*.}"
+  minor="${minor##+(0)}" # remove leading zeros
+  if [[ "$major" -gt "0" ]]; then
+    echo "arm64"
+  elif [[ "$minor" -ge "42" ]]; then
+    echo "arm64"
+  else
+    echo "x86_64"
+  fi
+}
+
 get_download_url() {
   local os arch
 
@@ -11,7 +29,7 @@ get_download_url() {
 
   # Apple M1 architecture (arm64) doesn't have binaries, so we install the x86_64 version
   if [[ "${os}" == "Darwin" && "${arch}" == "arm64" ]]; then
-    arch="x86_64"
+    arch="$(mac_arm64_binary)"
   fi
 
   # shellcheck disable=SC2154
@@ -19,7 +37,9 @@ get_download_url() {
 }
 
 download() {
-  curl -fsSL "$(get_download_url)" -o "${ASDF_DOWNLOAD_PATH}/buf.tar.gz" ||
+  local download_url
+  download_url="$(get_download_url)"
+  curl -fsSL "${download_url}" -o "${ASDF_DOWNLOAD_PATH}/buf.tar.gz" ||
     echo "Download failed!" 1>&2
 }
 

--- a/bin/install
+++ b/bin/install
@@ -7,7 +7,6 @@
 
 install() {
   if [ ! -f "${ASDF_DOWNLOAD_PATH}" ]; then
-    # shellcheck source=SCRIPTDIR/download
     source "$(dirname "$0")/download"
   fi
 


### PR DESCRIPTION
We only use the arm64 version for Buf releases equal to or greater than 0.42.0. 

Earlier versions still use x86_64.

Fixes https://github.com/truepay/asdf-buf/issues/3