### PR TITLE
chore: Upgrading tool versions
Upgrading building tools to:

bazel 3.7.2
cloudsql-proxy 1.27.0
firebase 9.22.0
github-cli 2.2.0
golang 1.17.3
nodejs 16.13.0
protoc 3.19.1
shellcheck 0.7.2
shfmt 3.4.0
terraform 1.0.10
yarn 1.22.10

Also upgrading Terraform providers and tf-truepay-module to v0.136.0

### DIFF
--- a/.tool-versions
+++ b/.tool-versions
@@ -6,3 +6,4 @@ golang 1.17.3
 protoc 3.19.1
 cloudsql-proxy 1.27.0
 firebase 9.22.0
+bazel 3.7.2

--- a/.tool-versions
+++ b/.tool-versions
@@ -4,3 +4,4 @@ terraform 1.0.10
 github-cli 2.2.0
 golang 1.17.3
 protoc 3.19.1
+cloudsql-proxy 1.27.0

--- a/.tool-versions
+++ b/.tool-versions
@@ -1,2 +1,3 @@
 shellcheck 0.7.2
 shfmt 3.2.4
+terraform 1.0.10

--- a/.tool-versions
+++ b/.tool-versions
@@ -5,3 +5,4 @@ github-cli 2.2.0
 golang 1.17.3
 protoc 3.19.1
 cloudsql-proxy 1.27.0
+firebase 9.22.0

--- a/.tool-versions
+++ b/.tool-versions
@@ -2,3 +2,4 @@ shellcheck 0.7.2
 shfmt 3.2.4
 terraform 1.0.10
 github-cli 2.2.0
+golang 1.17.3

--- a/.tool-versions
+++ b/.tool-versions
@@ -7,3 +7,4 @@ protoc 3.19.1
 cloudsql-proxy 1.27.0
 firebase 9.22.0
 bazel 3.7.2
+nodejs 16.13.0

--- a/.tool-versions
+++ b/.tool-versions
@@ -3,3 +3,4 @@ shfmt 3.4.0
 terraform 1.0.10
 github-cli 2.2.0
 golang 1.17.3
+protoc 3.19.1

--- a/.tool-versions
+++ b/.tool-versions
@@ -1,5 +1,5 @@
 shellcheck 0.7.2
-shfmt 3.2.4
+shfmt 3.4.0
 terraform 1.0.10
 github-cli 2.2.0
 golang 1.17.3

--- a/.tool-versions
+++ b/.tool-versions
@@ -1,3 +1,4 @@
 shellcheck 0.7.2
 shfmt 3.2.4
 terraform 1.0.10
+github-cli 2.2.0


### PR DESCRIPTION
Automated repository updates