### PR TITLE
Make the plugin add easy to copy for direct execution

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ Buf plugin for the asdf version manager.
 Plugin:
 
 ```shell_session
-$ asdf plugin-add buf https://github.com/truepay/asdf-buf
+asdf plugin add buf https://github.com/truepay/asdf-buf
 ```
 
 buf:


### PR DESCRIPTION
Hi! I was trying to install the plugin and found out that the plugin add is a bit incorrect and moreover - like proposed it can be used directly to copy it and execute the command.